### PR TITLE
fix: #89: AccessLightで先頭と末尾の頂点が近いとき末尾の点を削除

### DIFF
--- a/KokoHatena/Src/ShareData/BoardManager/Board/AccessBoard/AccessObject/AccessLight/AccessLight.cpp
+++ b/KokoHatena/Src/ShareData/BoardManager/Board/AccessBoard/AccessObject/AccessLight/AccessLight.cpp
@@ -141,6 +141,10 @@ namespace Kokoha
 			eventQueue.top().func();
 			eventQueue.pop();
 		}
+		if (m_posAry.front().distanceFromSq(m_posAry.back()) < EPSILON)
+		{
+			m_posAry.pop_back();
+		}
 
 		m_polygon = Polygon(m_posAry);
 	}


### PR DESCRIPTION
#89 